### PR TITLE
Fix the installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ tree data as JSON format for use in custom frontend implementation.
 ## Installation
 
 ```
-composer require silverstripe/silverstripe-elemental-decisiontree-output
+composer require silverstripeltd/silverstripe-elemental-decisiontree-json
 ```
 
 ## License


### PR DESCRIPTION
This module is loaded on packagist as `silverstripeltd/silverstripe-elemental-decisiontree-json` and the command to require it in the readme doesn't currently work.